### PR TITLE
:sparkles: Implement ssl connection

### DIFF
--- a/lib/soliton.rb
+++ b/lib/soliton.rb
@@ -1,2 +1,14 @@
 # frozen_string_literal: true
 require "soliton/main"
+
+module Soliton
+  class << self
+    def configure
+      yield configuration
+    end
+
+    def configuration
+      Server::Configuration.instance
+    end
+  end
+end

--- a/lib/soliton/router.rb
+++ b/lib/soliton/router.rb
@@ -80,7 +80,7 @@ module Soliton
       env[PARAMS] ||= {}
 
       if !env.key?(ROUTER_PARSED_BODY) && (input = env[::Rack::RACK_INPUT]) and
-           input.rewind
+         input.rewind
         env[PARAMS].merge!(::Rack::Utils.parse_nested_query(input.read))
         input.rewind
       end

--- a/lib/soliton/server.rb
+++ b/lib/soliton/server.rb
@@ -3,8 +3,16 @@ require "soliton/http/responder"
 require "soliton/http/request_parser"
 require "socket"
 require "soliton/logger"
+require 'openssl'
+require 'singleton'
+
 module Soliton
   class Server
+    class Configuration
+      include Singleton
+      attr_accessor :port, :host, :ssl_cert, :ssl_key, :ssl_enabled
+    end
+    include OpenSSL
     PORT = ENV.fetch("PORT", 3000)
     HOST = ENV.fetch("HOST", "127.0.0.1").freeze
     attr_accessor :app
@@ -15,9 +23,10 @@ module Soliton
     end
 
     def start
-      socket = listen_on_socket
-      logger = Logger.new($stdout)
+      server_setting = Server::Configuration.instance
 
+      socket = server_setting.ssl_enabled ? listen_on_socket_with_ssl(server_setting.ssl_cert, server_setting.ssl_key) : listen_on_socket
+      logger = Logger.new($stdout)
       logger.info "Soliton is running on #{HOST}:#{PORT}"
       loop do # 新しいコネクションを継続的にリッスンする
         conn, _addr_info = socket.accept
@@ -27,8 +36,17 @@ module Soliton
       rescue StandardError => e
         logger.error e
       ensure # コネクションを常にクローズする
+        logger.info "Completed #{status} #{Http::Responder::STATUS_MESSAGES[status]}"
         conn&.close
       end
+    end
+
+    def listen_on_socket_with_ssl(cert, key)
+      ctx = SSL::SSLContext.new
+      ctx.cert = X509::Certificate.new(File.read(cert))
+      ctx.key = PKey::RSA.new(File.read(key))
+      svr = TCPServer.new(HOST, PORT)
+      SSL::SSLServer.new(svr, ctx)
     end
 
     def listen_on_socket


### PR DESCRIPTION
## :ticket: チケット

## :memo: 概要
ssl 接続に対応
ついでに仕組みを書いておく

サーバー側にはサーバー証明書と秘密鍵を置く。
クライアントから TLS でのリクエストがあると、証明書をクライアントに返す。
クライアントは、証明書に埋め込まれた公開鍵を使って、共通鍵を暗号化してサーバーに渡す
サーバーは秘密鍵を使って共通鍵を復号する
以降、共通鍵を使って暗号化して通信を行う

```ruby
Soliton.configure do |config|
  config.ssl_enabled = true
  config.ssl_cert = "./cert.pem"
  config.ssl_key = "./key.pem"
end
```

## :stuck_out_tongue: やってないこと

## :white_check_mark: 動作確認