### PR TITLE
:sparkles: Introduce middleware for cookie

### DIFF
--- a/lib/soliton/http/request_parser.rb
+++ b/lib/soliton/http/request_parser.rb
@@ -68,7 +68,7 @@ module Soliton
         def rack_headers(headers)
           # Rackは、全ヘッダーがHTTP_がプレフィックスされ
           # かつ大文字であることを期待する
-          headers.transform_keys { |key| "HTTP_#{key.upcase}" }
+          headers.transform_keys {|key| "HTTP_#{key.upcase}" }
         end
 
         def read_body(conn:, method:, headers:)

--- a/lib/soliton/main.rb
+++ b/lib/soliton/main.rb
@@ -2,7 +2,6 @@
 require "soliton/server"
 require "soliton/application"
 require "soliton/version"
-require "soliton/test"
 
 module Soliton
   class App

--- a/lib/soliton/middleware/builder.rb
+++ b/lib/soliton/middleware/builder.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+module Soliton
+  module Middleware
+    class Builder
+      def initialize(&block)
+        @use = []
+        instance_eval(&block) if block_given?
+      end
+
+      def use(middleware, *args, &block)
+        @use << proc {|app| middleware.new(app, *args, &block) }
+      end
+
+      def run(app)
+        @app = app
+      end
+
+      def call(env)
+        build_app.call(env)
+      end
+
+      private
+
+      def build_app
+        @use.reverse.inject(@app) {|a, e| e.call(a) }
+      end
+    end
+  end
+end

--- a/lib/soliton/middleware/cookie.rb
+++ b/lib/soliton/middleware/cookie.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Soliton
+  module Middleware
+    class Cookie
+      def initialize(app)
+        @app = app
+      end
+
+      def call(env)
+        status, headers, body = @app.call(env)
+        headers['Set-Cookie'] = 'foo=bar'
+        [status, headers, body]
+      end
+    end
+  end
+end

--- a/lib/soliton/server.rb
+++ b/lib/soliton/server.rb
@@ -1,13 +1,15 @@
 # frozen_string_literal: true
 require "soliton/http/responder"
 require "soliton/http/request_parser"
+require "soliton/middleware/builder"
+require "soliton/middleware/cookie"
 require "socket"
 require "soliton/logger"
 require 'openssl'
 require 'singleton'
-
 module Soliton
   class Server
+
     class Configuration
       include Singleton
       attr_accessor :port, :host, :ssl_cert, :ssl_key, :ssl_enabled
@@ -19,11 +21,12 @@ module Soliton
 
     # app: Rackアプリ
     def initialize(app)
-      self.app = app
+      @app = app
     end
 
     def start
       server_setting = Server::Configuration.instance
+      application = @app
 
       socket = server_setting.ssl_enabled ? listen_on_socket_with_ssl(server_setting.ssl_cert, server_setting.ssl_key) : listen_on_socket
       logger = Logger.new($stdout)
@@ -31,7 +34,11 @@ module Soliton
       loop do # 新しいコネクションを継続的にリッスンする
         conn, _addr_info = socket.accept
         request = Http::RequestParser.call(conn)
-        status, headers, body = app.call(request)
+        builder = Soliton::Middleware::Builder.new do
+          use Soliton::Middleware::Cookie
+          run application
+        end
+        status, headers, body = builder.call(request)
         Http::Responder.call(conn, status, headers, body)
       rescue StandardError => e
         logger.error e

--- a/lib/soliton/test.rb
+++ b/lib/soliton/test.rb
@@ -1,5 +1,0 @@
-require "soliton/router"
-
-Soliton::Router.routing do
-  get "/hello/:id", to: ->(env) { [200, {}, ["Hello, World!"]] }
-end


### PR DESCRIPTION
## :ticket: チケット

## :memo: 概要
cookie を実装する準備として、Middleware::Builder を導入
各 middlerware は app を受け取り、call メソッドを実装すれば、記述順に実行されるようになる。
app.call 前は request に対する処理 app.call 後は response に対する処理を書くことができる

```ruby
builder = Soliton::Middleware::Builder.new do
          use Soliton::Middleware::Cookie
          run application
end
builder.call(env)
```

## :stuck_out_tongue: やってないこと

## :white_check_mark: 動作確認