### PR TITLE
Allow option to be passed to the cookie

### DIFF
--- a/lib/soliton/http/responder.rb
+++ b/lib/soliton/http/responder.rb
@@ -11,7 +11,13 @@ module Soliton
         content_length = body.sum(&:length)
         conn.write("Content-Length: #{content_length}\r\n")
         headers.each_pair do |name, value|
-          conn.write("#{name}: #{value}\r\n")
+          if value.is_a?(Array)
+            value.each do |v|
+              conn.write("#{name}: #{v}\r\n")
+            end
+          else 
+            conn.write("#{name}: #{value}\r\n")
+          end
         end
 
         # コネクションを開きっぱなしにしたくないことを伝える

--- a/lib/soliton/middleware/cookie.rb
+++ b/lib/soliton/middleware/cookie.rb
@@ -23,13 +23,13 @@ module Soliton
     end
   end
 
-   module Cookies
-      def cookies
-         # TODO request の取得方法を変更する
-         request = Soliton::Context.instance.context
-         request['soliton.cookies']
-      end
-   end
+  module Cookies
+    def cookies
+      # TODO: request の取得方法を変更する
+      request = Soliton::Context.instance.context
+      request['soliton.cookies']
+    end
+  end
 
   class CookieJar
     def self.build(req, cookies)
@@ -53,7 +53,6 @@ module Soliton
 
     def []=(name, options)
       if options.is_a?(Hash)
-        options.symbolize_keys!
         value = options[:value]
       else
         value = options
@@ -74,7 +73,10 @@ module Soliton
     end
 
     def to_header
-      @set_cookies.map {|k, v| "#{k}=#{v}" }.join "; "
+      @set_cookies.map do |name, options|
+        formatted_options = options.except(:value).map { |key, value| "#{key}=#{value}" }.join("; ")
+        "#{name}=#{options[:value]}; #{formatted_options}"
+      end
     end
   end
 end


### PR DESCRIPTION
## :ticket: チケット

## :memo: 概要
cookie で option を渡せるように変更

```ruby
cookie[:user_name] = {
  value: "hikaru-nakayama",
  Path: "/"
}
```

## :stuck_out_tongue: やってないこと

## :white_check_mark: 動作確認